### PR TITLE
fix name and placetype properties

### DIFF
--- a/feature/geojson.go
+++ b/feature/geojson.go
@@ -87,6 +87,7 @@ func (f *GeoJSONFeature) Name() string {
 
 	possible := []string{
 		"properties.name",
+		"properties.wof:name",
 	}
 
 	name := utils.StringProperty(f.Bytes(), possible, "")
@@ -102,6 +103,7 @@ func (f *GeoJSONFeature) Placetype() string {
 
 	possible := []string{
 		"properties.placetype",
+		"properties.wof:placetype",
 	}
 
 	pt := utils.StringProperty(f.Bytes(), possible, "")


### PR DESCRIPTION
Hello the WOF team :heart: !

I was using your project [go-whosonfirst-shapefile](https://github.com/whosonfirst/go-whosonfirst-shapefile) on `whosonfirst-data-admin-it` dataset.... And I noticed that shapefile properties were inccorect.

Here is what I got :

| Id | Name | Placetype | Inception | Cessation |
| --- | --- | --- |  --- |  --- | 
| 1242584443 | -4207638166098101249 | point | uuuu | uuuu |
| 101771399 | -4217765509466406178 | polygon | uuuu | uuuu |
| 1226009449 | -3422702992605245228 | point | uuuu | uuuu |

I found that alternative name properties for `name` and `placetype` were missing, so... PR :smile:.